### PR TITLE
Remove unused dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,44 @@
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
             <version>3.141.59</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-exec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.seleniumhq.selenium</groupId>
+                    <artifactId>selenium-safari-driver</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.seleniumhq.selenium</groupId>
+                    <artifactId>selenium-opera-driver</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>net.bytebuddy</groupId>
+                    <artifactId>byte-buddy</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.squareup.okhttp3</groupId>
+                    <artifactId>okhttp</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.seleniumhq.selenium</groupId>
+                    <artifactId>selenium-edge-driver</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.squareup.okio</groupId>
+                    <artifactId>okio</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.checkerframework</groupId>
+                    <artifactId>checker-compat-qual</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
@jomarnavarro Hi, I am a user of project **_con.vamonostest:introWebDriver:1.0-SNAPSHOT_**. I found that its pom file introduced **_21_** dependencies. However, among them, **_9_** libraries (**_42%_**) have not been used by your project (the redundant dependencies are listed below). This PR helps **_con.vamonostest:introWebDriver:1.0-SNAPSHOT_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards


## Redundant dependencies----
<pre><code>
com.google.code.findbugs:jsr305:jar:1.3.9:compile
com.squareup.okio:okio:jar:1.14.0:compile
net.bytebuddy:byte-buddy:jar:1.8.15:compile
org.checkerframework:checker-compat-qual:jar:2.0.0:compile
org.seleniumhq.selenium:selenium-safari-driver:jar:3.141.59:compile
org.seleniumhq.selenium:selenium-edge-driver:jar:3.141.59:compile
org.seleniumhq.selenium:selenium-opera-driver:jar:3.141.59:compile
org.apache.commons:commons-exec:jar:1.3:compile
com.squareup.okhttp3:okhttp:jar:3.11.0:compile
</code></pre>